### PR TITLE
chore: Add Netlify redirection rules

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,12 @@
+[[redirects]]
+  from = "/0.109.7/*"
+  to = "/0.109.7/:splat"
+  status = 200
+  force = false
+
+[[redirects]]
+  from = "/*"
+  to = "https://nocodb.com/docs/product-docs/:splat"
+  status = 301
+  force = true
+  conditions = { Host = "docs.nocodb.com" } 


### PR DESCRIPTION
- Redirect all paths on `docs.nocodb.com` to `nocodb.com/docs/product-docs`, except for `/0.109.7`
- Re https://github.com/nocodb/nocohub/issues/5188